### PR TITLE
feat: Implement collaborative workspaces

### DIFF
--- a/public/collaborate.html
+++ b/public/collaborate.html
@@ -1,0 +1,92 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Collaborative Workspace - R3L</title>
+    <link rel="stylesheet" href="/css/rel-f-global.css">
+    <link rel="stylesheet" href="/css/messaging.css">
+    <style>
+        .workspace-container {
+            display: flex;
+            height: calc(100vh - 60px);
+        }
+        .sidebar {
+            width: 250px;
+            border-right: 1px solid var(--color-border);
+            padding: var(--space-2);
+            display: flex;
+            flex-direction: column;
+        }
+        .main-content {
+            flex-grow: 1;
+            display: flex;
+            flex-direction: column;
+        }
+        .editor-container {
+            flex-grow: 1;
+            padding: var(--space-2);
+        }
+        #document-editor {
+            width: 100%;
+            height: 100%;
+            border: 1px solid var(--color-border);
+            padding: var(--space-2);
+            font-family: monospace;
+        }
+        .chat-panel {
+            width: 300px;
+            border-left: 1px solid var(--color-border);
+            display: flex;
+            flex-direction: column;
+        }
+        .chat-messages {
+            flex-grow: 1;
+            padding: var(--space-2);
+            overflow-y: auto;
+        }
+        .chat-input {
+            padding: var(--space-2);
+            border-top: 1px solid var(--color-border);
+        }
+        #chat-input-field {
+            width: 100%;
+            padding: var(--space-2);
+            border: 1px solid var(--color-border);
+        }
+    </style>
+</head>
+<body>
+    <header class="main-header">
+        <div class="logo">R3L</div>
+        <nav id="main-nav"></nav>
+    </header>
+
+    <main class="container">
+        <div class="workspace-container">
+            <aside class="sidebar">
+                <h3>Documents</h3>
+                <ul id="document-list"></ul>
+                <button id="new-doc-btn">New Document</button>
+                <hr>
+                <h3>Participants</h3>
+                <ul id="participant-list"></ul>
+            </aside>
+            <section class="main-content">
+                <div class="editor-container">
+                    <textarea id="document-editor" placeholder="Start collaborating..."></textarea>
+                </div>
+            </section>
+            <aside class="chat-panel">
+                <div class="chat-messages" id="chat-messages"></div>
+                <div class="chat-input">
+                    <input type="text" id="chat-input-field" placeholder="Type a message...">
+                </div>
+            </aside>
+        </div>
+    </main>
+
+    <script type="module" src="/js/components/navigation.js"></script>
+    <script type="module" src="/js/collaborate.js"></script>
+</body>
+</html>

--- a/public/js/collaborate.js
+++ b/public/js/collaborate.js
@@ -1,0 +1,161 @@
+import { NavigationBar } from './components/navigation.js';
+
+document.addEventListener('DOMContentLoaded', () => {
+    NavigationBar.init('collaborate');
+
+    const documentList = document.getElementById('document-list');
+    const newDocBtn = document.getElementById('new-doc-btn');
+    const participantList = document.getElementById('participant-list');
+    const documentEditor = document.getElementById('document-editor');
+    const chatMessages = document.getElementById('chat-messages');
+    const chatInputField = document.getElementById('chat-input-field');
+
+    let socket = null;
+    let workspaceId = null;
+
+    async function init() {
+        const urlParams = new URLSearchParams(window.location.search);
+        workspaceId = urlParams.get('id');
+
+        if (!workspaceId) {
+            const response = await fetch('/api/workspaces', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ name: 'My New Workspace' })
+            });
+            const workspace = await response.json();
+            window.location.href = `/collaborate.html?id=${workspace.id}`;
+        } else {
+            connectWebSocket();
+        }
+    }
+
+    function connectWebSocket() {
+        const protocol = window.location.protocol === 'https:' ? 'wss:' : 'ws:';
+        const wsUrl = `${protocol}//${window.location.host}/api/workspaces/${workspaceId}/ws`;
+
+        socket = new WebSocket(wsUrl);
+
+        socket.addEventListener('open', () => {
+            console.log('WebSocket connection established');
+        });
+
+        socket.addEventListener('message', (event) => {
+            const message = JSON.parse(event.data);
+            handleWebSocketMessage(message);
+        });
+
+        socket.addEventListener('close', () => {
+            console.log('WebSocket connection closed. Reconnecting...');
+            setTimeout(connectWebSocket, 1000);
+        });
+
+        socket.addEventListener('error', (error) => {
+            console.error('WebSocket error:', error);
+        });
+    }
+
+    function handleWebSocketMessage(message) {
+        switch (message.type) {
+            case 'workspace_state':
+                updateUI(message.state);
+                break;
+            case 'document_created':
+                addDocumentToList(message.document);
+                break;
+            case 'document_updated':
+                if (documentEditor.dataset.docId === message.documentId) {
+                    documentEditor.value = message.content;
+                }
+                break;
+            case 'user_joined':
+                addParticipantToList(message);
+                break;
+            case 'user_left':
+                removeParticipantFromList(message.userId);
+                break;
+            case 'chat_message':
+                addChatMessage(message);
+                break;
+        }
+    }
+
+    function updateUI(state) {
+        documentList.innerHTML = '';
+        state.documents.forEach(addDocumentToList);
+
+        participantList.innerHTML = '';
+        state.participants.forEach(addParticipantToList);
+    }
+
+    function addDocumentToList(doc) {
+        const li = document.createElement('li');
+        li.textContent = doc.name;
+        li.dataset.docId = doc.id;
+        li.addEventListener('click', () => {
+            documentEditor.dataset.docId = doc.id;
+            documentEditor.value = doc.content;
+        });
+        documentList.appendChild(li);
+    }
+
+    function addParticipantToList(participant) {
+        const li = document.createElement('li');
+        li.textContent = participant.userName;
+        li.dataset.userId = participant.userId;
+        participantList.appendChild(li);
+    }
+
+    function removeParticipantFromList(userId) {
+        const li = participantList.querySelector(`[data-user-id="${userId}"]`);
+        if (li) {
+            li.remove();
+        }
+    }
+
+    function addChatMessage(message) {
+        const div = document.createElement('div');
+        div.innerHTML = `<b>${message.userName}:</b> ${message.message}`;
+        chatMessages.appendChild(div);
+        chatMessages.scrollTop = chatMessages.scrollHeight;
+    }
+
+    newDocBtn.addEventListener('click', async () => {
+        const docName = prompt('Enter document name:');
+        if (docName) {
+            const response = await fetch(`/api/workspaces/${workspaceId}/documents`, {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ name: docName })
+            });
+            const newDoc = await response.json();
+            addDocumentToList(newDoc);
+        }
+    });
+
+    documentEditor.addEventListener('input', () => {
+        const docId = documentEditor.dataset.docId;
+        if (docId && socket && socket.readyState === WebSocket.OPEN) {
+            socket.send(JSON.stringify({
+                type: 'document_update',
+                documentId: docId,
+                content: documentEditor.value
+            }));
+        }
+    });
+
+    chatInputField.addEventListener('keypress', (e) => {
+        if (e.key === 'Enter') {
+            const text = chatInputField.value;
+            if (text && socket && socket.readyState === WebSocket.OPEN) {
+                socket.send(JSON.stringify({
+                    type: 'chat_message',
+                    text: text
+                }));
+                chatInputField.value = '';
+            }
+        }
+    });
+
+    init();
+});

--- a/public/js/components/navigation.js
+++ b/public/js/components/navigation.js
@@ -72,6 +72,10 @@ export class NavigationBar {
                   <span class="material-icons">chat</span>
                   Messages
                 </a>
+                <a href="/collaborate.html" class="dropdown-item ${currentPage === 'collaborate' ? 'active' : ''}">
+                  <span class="material-icons">groups</span>
+                  Collaborate
+                </a>
               </div>
             </li>
             

--- a/src/router.ts
+++ b/src/router.ts
@@ -195,6 +195,10 @@ export class Router {
       return this.handleMessagingRoutes(request, env, path);
     }
 
+    if (path.startsWith('/api/workspaces/')) {
+      return this.handleWorkspaceRoutes(request, env, path);
+    }
+
     // Associations: connections and related
     if (path.startsWith('/api/connections/')) {
       return this.handleAssociationRoutes(request, env, path);
@@ -2769,6 +2773,66 @@ export class Router {
         console.error('Error performing location search:', error);
         return this.errorResponse('Failed to perform location search');
       }
+    }
+
+    return this.notFoundResponse();
+  }
+
+  /**
+   * Handle workspace routes
+   */
+  private async handleWorkspaceRoutes(request: Request, env: Env, path: string): Promise<Response> {
+    const authenticatedUserId = await this.getAuthenticatedUser(request, env);
+    if (!authenticatedUserId) {
+      return this.errorResponse('Authentication required', 401);
+    }
+
+    // Create a new workspace
+    if (path === '/api/workspaces' && request.method === 'POST') {
+      const { name } = await request.json();
+      if (!name) {
+        return this.errorResponse('Workspace name is required', 400);
+      }
+
+      const id = env.R3L_WORKSPACES.newUniqueId();
+      const stub = env.R3L_WORKSPACES.get(id);
+
+      // We can initialize the workspace by sending a request to it.
+      await stub.fetch(new Request(`https://workspace/initialize`, {
+          method: 'POST',
+          body: JSON.stringify({ name }),
+          headers: { 'Content-Type': 'application/json' },
+      }));
+
+      // Store workspace metadata (e.g., in D1)
+      // For now, we'll just return the ID. A more robust implementation would store this.
+
+      return this.jsonResponse({ id: id.toString(), name });
+    }
+
+    // Forward request to a specific workspace DO
+    const match = path.match(/^\/api\/workspaces\/([a-zA-Z0-9]+)(\/.*)?$/);
+    if (match) {
+        const workspaceId = match[1];
+        const subpath = match[2] || '/';
+
+        try {
+            const doId = env.R3L_WORKSPACES.idFromString(workspaceId);
+            const stub = env.R3L_WORKSPACES.get(doId);
+
+            // Add user info to the request URL for the DO
+            const url = new URL(request.url);
+            const user = await this.userHandler.getUser(authenticatedUserId, env);
+            url.searchParams.set('userId', authenticatedUserId);
+            url.searchParams.set('userName', user?.username || 'Anonymous');
+
+            const newRequest = new Request(url, request);
+
+            return await stub.fetch(newRequest);
+
+        } catch (e) {
+            return this.errorResponse('Invalid workspace ID format', 400);
+        }
     }
 
     return this.notFoundResponse();

--- a/src/workspace.ts
+++ b/src/workspace.ts
@@ -1,0 +1,204 @@
+import { Env } from './types/env';
+
+// Define the structure of a document within a workspace
+interface WorkspaceDocument {
+  id: string;
+  name: string;
+  content: string;
+  version: number;
+}
+
+// Define the structure of the workspace state
+interface WorkspaceState {
+  name: string;
+  documents: WorkspaceDocument[];
+  participants: any[];
+  permissions: Map<string, 'read' | 'write' | 'admin'>;
+}
+
+export class Workspace {
+  state: DurableObjectState;
+  env: Env;
+  connections: Map<string, WebSocket>;
+  workspaceState: WorkspaceState;
+
+  constructor(state: DurableObjectState, env: Env) {
+    this.state = state;
+    this.env = env;
+    this.connections = new Map();
+    this.workspaceState = {
+      name: 'New Workspace',
+      documents: [],
+      participants: [],
+      permissions: new Map(),
+    };
+
+    // Load initial state from storage
+    this.state.blockConcurrencyWhile(async () => {
+      const storedState: WorkspaceState | undefined = await this.state.storage.get('workspaceState');
+      if (storedState) {
+        this.workspaceState = storedState;
+      }
+    });
+  }
+
+  async fetch(request: Request): Promise<Response> {
+    const url = new URL(request.url);
+
+    if (url.pathname === '/initialize' && request.method === 'POST') {
+        const { name } = await request.json();
+        this.workspaceState.name = name;
+        await this.state.storage.put('workspaceState', this.workspaceState);
+        return new Response(null, { status: 200 });
+    }
+
+    // Upgrade to WebSocket for real-time collaboration
+    if (request.headers.get('Upgrade') === 'websocket') {
+      const { 0: client, 1: server } = new WebSocketPair();
+      this.handleWebSocket(server, url);
+      return new Response(null, { status: 101, webSocket: client });
+    }
+
+    // API endpoints for managing the workspace
+    if (url.pathname.startsWith('/api/workspaces/')) {
+        return this.handleApiRequest(request, url);
+    }
+
+    return new Response('Not found', { status: 404 });
+  }
+
+  handleWebSocket(server: any, url: URL) {
+    server.accept();
+
+    const userId = url.searchParams.get('userId') || 'anonymous';
+    const userName = url.searchParams.get('userName') || 'Anonymous User';
+    const connectionId = crypto.randomUUID();
+    server.userId = userId;
+    this.connections.set(connectionId, server);
+
+    // Add user to participants list
+    if (!this.workspaceState.participants.some((p: any) => p.userId === userId)) {
+        this.workspaceState.participants.push({ userId, userName, joinedAt: new Date().toISOString() });
+    }
+
+    // Send current state to the new connection
+    server.send(JSON.stringify({ type: 'workspace_state', state: this.workspaceState }));
+
+    // Announce user joined
+    this.broadcast({ type: 'user_joined', userId, userName, timestamp: new Date().toISOString() }, connectionId);
+
+    server.addEventListener('message', async (event) => {
+        try {
+          const message = JSON.parse(event.data as string);
+          // Handle different message types (e.g., document updates, chat)
+          this.handleWebSocketMessage(message, connectionId, userId, userName);
+        } catch (error) {
+          console.error('Error handling WebSocket message:', error);
+        }
+    });
+
+    server.addEventListener('close', () => {
+        this.connections.delete(connectionId);
+        // Remove user from participants if it's their last connection
+        const userHasOtherConnections = Array.from(this.connections.values()).some(
+            (ws: any) => ws.userId === userId
+        );
+        if(!userHasOtherConnections) {
+            this.workspaceState.participants = this.workspaceState.participants.filter(
+                (p: any) => p.userId !== userId
+            );
+        }
+        this.broadcast({ type: 'user_left', userId, userName, timestamp: new Date().toISOString() });
+    });
+  }
+
+  async handleWebSocketMessage(message: any, connectionId: string, userId: string, userName: string) {
+    switch (message.type) {
+        case 'document_update':
+            // Logic to update a document's content
+            await this.updateDocument(message.documentId, message.content, userId, userName);
+            break;
+        case 'chat_message':
+            // The messaging handler will store and broadcast the message
+            const { MessagingHandler } = await import('./handlers/messaging.js');
+            const messagingHandler = new MessagingHandler();
+            await messagingHandler.sendMessage(
+                userId,
+                `ws-${this.state.id.toString()}`, // Use workspace ID as the recipient
+                message.text,
+                [],
+                this.env
+            );
+
+            // Also broadcast to the local workspace connections
+            this.broadcast({
+                type: 'chat_message',
+                userId,
+                userName,
+                message: message.text,
+                timestamp: new Date().toISOString()
+            }, connectionId);
+            break;
+        // Add other cases as needed
+    }
+  }
+
+  async handleApiRequest(request: Request, url: URL): Promise<Response> {
+    const pathSegments = url.pathname.split('/');
+    const action = pathSegments[3]; // e.g., 'documents'
+
+    if (request.method === 'POST' && action === 'documents') {
+        const { name } = await request.json();
+        const newDoc = await this.createDocument(name);
+        return new Response(JSON.stringify(newDoc), { status: 201 });
+    }
+
+    if (request.method === 'GET' && action === 'state') {
+        return new Response(JSON.stringify(this.workspaceState), { headers: { 'Content-Type': 'application/json' } });
+    }
+
+    return new Response('Invalid API request', { status: 400 });
+  }
+
+  async createDocument(name: string): Promise<WorkspaceDocument> {
+    const newDoc: WorkspaceDocument = {
+        id: crypto.randomUUID(),
+        name,
+        content: '',
+        version: 1,
+    };
+    this.workspaceState.documents.push(newDoc);
+    await this.state.storage.put('workspaceState', this.workspaceState);
+    this.broadcast({ type: 'document_created', document: newDoc });
+    return newDoc;
+  }
+
+  async updateDocument(documentId: string, content: string, userId: string, userName: string) {
+    const doc = this.workspaceState.documents.find(d => d.id === documentId);
+    if (doc) {
+        doc.content = content;
+        doc.version += 1;
+        await this.state.storage.put('workspaceState', this.workspaceState);
+        this.broadcast({
+            type: 'document_updated',
+            documentId,
+            content,
+            version: doc.version,
+            updatedBy: { userId, userName }
+        });
+    }
+  }
+
+  broadcast(message: any, excludeConnectionId?: string) {
+    const messageString = JSON.stringify(message);
+    for (const [id, connection] of this.connections.entries()) {
+      if (id !== excludeConnectionId) {
+        try {
+          connection.send(messageString);
+        } catch (error) {
+          console.error('Error broadcasting message:', error);
+        }
+      }
+    }
+  }
+}

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -76,6 +76,10 @@
       {
         "name": "R3L_COLLABORATION",
         "class_name": "CollaborationRoom"
+      },
+      {
+        "name": "R3L_WORKSPACES",
+        "class_name": "Workspace"
       }
     ]
   },


### PR DESCRIPTION
This commit introduces a new collaborative workspaces feature.

It adds a new page at `/collaborate.html` where users can engage in real-time document editing and chat.

Backend changes include:
- A new `Workspace` Durable Object to manage the state of each collaborative session, including documents, participants, and real-time updates via WebSockets.
- New API endpoints under `/api/workspaces/` to create and interact with workspaces.
- Integration with the existing `MessagingHandler` to persist chat messages in the D1 database.

Frontend changes include:
- `collaborate.html` provides a three-panel UI for document management, a text editor, and a chat.
- `collaborate.js` handles the client-side logic, including WebSocket connections and UI updates.
- A link to the new feature has been added to the main navigation under the "Connect" dropdown.

Known limitations:
- The implementation uses a new `Workspace` Durable Object instead of leveraging the existing `CollaborationRoom` as initially suggested. This was a design decision to better support a multi-document workspace.
- While chat messages are persisted, the UI does not currently load a workspace's message history on load. It only displays messages sent during the current session.