### PR TITLE
feat: Implement backend for Association Web

### DIFF
--- a/jest.config.cjs
+++ b/jest.config.cjs
@@ -1,0 +1,8 @@
+/** @type {import('ts-jest').JestConfigWithTsJest} */
+module.exports = {
+  preset: 'ts-jest',
+  testEnvironment: 'node',
+  moduleNameMapper: {
+    '^(.*)\\.js$': '$1',
+  },
+};

--- a/src/router.ts
+++ b/src/router.ts
@@ -196,7 +196,7 @@ export class Router {
     }
 
     // Associations: connections and related
-    if (path.startsWith('/api/connections/')) {
+    if (path.startsWith('/api/connections')) {
       return this.handleAssociationRoutes(request, env, path);
     }
 
@@ -2036,7 +2036,7 @@ export class Router {
     }
 
     // Handle connection routes
-    if (path.startsWith('/api/connections/')) {
+    if (path.startsWith('/api/connections')) {
       return this.handleConnectionRoutes(request, env, path, authenticatedUserId);
     }
 
@@ -2345,7 +2345,7 @@ export class Router {
         `;
 
         await env.R3L_DB.prepare(insert)
-          .bind(id, userId, targetUserId, type, message, now, now)
+          .bind(id, userId, targetUserId, type, 'pending', message, now, now)
           .run();
 
         return this.jsonResponse({ success: true, id });
@@ -2373,6 +2373,47 @@ export class Router {
       } catch (error) {
         console.error('Error removing connection:', error);
         return this.errorResponse('Failed to remove connection');
+      }
+    }
+
+    // Update connection visibility
+    if (path.match(/^\/api\/connections\/[^/]+\/visibility$/) && request.method === 'PATCH') {
+      try {
+        const connectionId = path.split('/')[3];
+        const { visibility } = (await request.json()) as { visibility: string };
+
+        if (!visibility || !['public', 'private', 'mutual'].includes(visibility)) {
+          return this.errorResponse('Invalid visibility value. Must be one of: public, private, mutual.', 400);
+        }
+
+        // Check if the user is part of the connection
+        const connectionResult = await env.R3L_DB.prepare(
+          `SELECT user_id, connected_user_id FROM connections WHERE id = ?`
+        ).bind(connectionId).first();
+
+        if (!connectionResult) {
+          return this.errorResponse('Connection not found', 404);
+        }
+
+        const conn = connectionResult as { user_id: string; connected_user_id: string };
+
+        if (conn.user_id !== userId && conn.connected_user_id !== userId) {
+          return this.errorResponse('Unauthorized to update this connection', 403);
+        }
+
+        // Update the visibility
+        const updateQuery = `
+          UPDATE connections
+          SET visibility = ?, updated_at = ?
+          WHERE id = ?
+        `;
+
+        await env.R3L_DB.prepare(updateQuery).bind(visibility, Date.now(), connectionId).run();
+
+        return this.jsonResponse({ success: true });
+      } catch (error) {
+        console.error('Error updating connection visibility:', error);
+        return this.errorResponse('Failed to update connection visibility');
       }
     }
 

--- a/src/tests/connections.test.ts
+++ b/src/tests/connections.test.ts
@@ -1,0 +1,163 @@
+import { Router } from '../router';
+import { Env } from '../types/env';
+
+// Mock the crypto.randomUUID function
+const mockUUID = 'mock-uuid';
+global.crypto = {
+  ...global.crypto,
+  randomUUID: () => mockUUID,
+};
+
+describe('Connection Routes', () => {
+  let router: Router;
+  let env: Env;
+  let request: Request;
+
+  beforeEach(() => {
+    router = new Router();
+    const db = {
+      prepare: jest.fn(() => ({
+        bind: jest.fn(() => ({
+          first: jest.fn(),
+          all: jest.fn(() => Promise.resolve({ results: [] })),
+          run: jest.fn(),
+        })),
+      })),
+    };
+    const connections = {
+      get: jest.fn(() => ({
+        fetch: jest.fn(),
+      })),
+      idFromName: jest.fn(),
+    };
+    env = {
+      R3L_DB: db,
+      R3L_CONNECTIONS: connections,
+      JWT_SECRET: 'test-secret',
+    } as any;
+  });
+
+  it('should be true', () => {
+    expect(true).toBe(true);
+  });
+
+  describe('GET /api/connections', () => {
+    it('should return a list of connections', async () => {
+      const mockConnections = [
+        {
+          id: 'conn1',
+          user_id: 'user1',
+          connected_user_id: 'user2',
+          type: 'mutual',
+          status: 'accepted',
+          visibility: 'private',
+          created_at: Date.now(),
+          updated_at: Date.now(),
+          connected_username: 'user2',
+          connected_display_name: 'User Two',
+          connected_avatar_url: 'avatar2.png',
+        },
+      ];
+
+      const mockDb = env.R3L_DB as any;
+      const mockAll = jest.fn().mockResolvedValue({ results: mockConnections });
+      const mockBind = jest.fn(() => ({ all: mockAll }));
+      mockDb.prepare.mockReturnValue({ bind: mockBind });
+
+      // Mock the getAuthenticatedUser to return a user ID
+      (router as any).getAuthenticatedUser = jest.fn().mockResolvedValue('user1');
+
+      request = new Request('https://example.com/api/connections', {
+        method: 'GET',
+        headers: { 'Content-Type': 'application/json' },
+      });
+
+      const response = await router.handle(request, env);
+      const data = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(Array.isArray(data)).toBe(true);
+      expect(data.length).toBe(1);
+      expect(data[0].id).toBe('conn1');
+      expect(data[0].otherUser.username).toBe('user2');
+    });
+  });
+
+
+  describe('PATCH /api/connections/:connectionId/visibility', () => {
+    it('should update the visibility of a connection', async () => {
+      const connectionId = 'conn1';
+      const visibility = 'public';
+
+      const mockDb = env.R3L_DB as any;
+      const mockRun = jest.fn().mockResolvedValue({ success: true });
+      const mockFirst = jest.fn().mockResolvedValue({ user_id: 'user1', connected_user_id: 'user2' });
+      const mockBind = jest.fn(() => ({ run: mockRun, first: mockFirst }));
+      mockDb.prepare.mockImplementation((query: string) => {
+        if (query.trim().startsWith('SELECT')) {
+          return { bind: () => ({ first: mockFirst }) };
+        }
+        return { bind: mockBind };
+      });
+
+      // Mock the getAuthenticatedUser to return a user ID
+      (router as any).getAuthenticatedUser = jest.fn().mockResolvedValue('user1');
+
+      request = new Request(`https://example.com/api/connections/${connectionId}/visibility`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ visibility }),
+      });
+
+      const response = await router.handle(request, env);
+      const data = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(data.success).toBe(true);
+
+      expect(mockDb.prepare).toHaveBeenCalledWith(expect.stringContaining('UPDATE connections'));
+      expect(mockBind).toHaveBeenCalledWith(visibility, expect.any(Number), connectionId);
+    });
+  });
+
+  describe('POST /api/connections', () => {
+    it('should create a new connection request', async () => {
+      const targetUserId = 'user2';
+      const type = 'mutual';
+      const message = 'Hello!';
+
+      const mockDb = env.R3L_DB as any;
+      const mockRun = jest.fn().mockResolvedValue({ success: true });
+      const mockBind = jest.fn(() => ({ run: mockRun }));
+      mockDb.prepare.mockReturnValue({ bind: mockBind });
+
+      // Mock the getAuthenticatedUser to return a user ID
+      (router as any).getAuthenticatedUser = jest.fn().mockResolvedValue('user1');
+
+      request = new Request('https://example.com/api/connections', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ targetUserId, type, message }),
+      });
+
+      const response = await router.handle(request, env);
+      const data = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(data.success).toBe(true);
+      expect(data.id).toBe(mockUUID);
+
+      expect(mockDb.prepare).toHaveBeenCalledWith(expect.stringContaining('INSERT INTO connections'));
+      expect(mockBind).toHaveBeenCalledWith(
+        mockUUID,
+        'user1',
+        targetUserId,
+        type,
+        'pending',
+        message,
+        expect.any(Number),
+        expect.any(Number)
+      );
+    });
+  });
+});


### PR DESCRIPTION
This commit implements the backend functionality for the Association Web feature.

- Adds a new route `PATCH /api/connections/:connectionId/visibility` to manage the public/private status of a connection.
- Fixes a bug in the `POST /api/connections` route to correctly set the status of a new connection request to 'pending'.
- Adds a new test file `src/tests/connections.test.ts` with tests for the connection routes.
- Adds a `jest.config.cjs` file to configure the test environment.
- Fixes bugs in the router logic for matching connection routes.