### PR TITLE
🔒 [security] Add rate limiting to /api/messages endpoint

### DIFF
--- a/API.md
+++ b/API.md
@@ -572,6 +572,7 @@ Real-time collaborative editing (Yjs protocol).
 | /api/forgot-password | 3 | 1 hour |
 | /api/reset-password | 3 | 1 hour |
 | /api/drift | 20 | 10 minutes |
+| /api/messages | 60 | 10 minutes |
 | /api/feedback | 3 | 1 hour |
 | /api/files/:id/vitality | 10 | 1 minute |
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -2377,6 +2377,9 @@ app.get('/api/messages/:partner_id', async (c) => {
 
 // POST /api/messages: Send a message
 app.post('/api/messages', async (c) => {
+  if (!await checkRateLimit(c, 'messages', 60, 600)) {
+    return c.json({ error: 'Sending messages too fast. Please wait.' }, 429);
+  }
   const sender_id = c.get('user_id');
   const { receiver_id, content, encrypt } = await c.req.json();
 


### PR DESCRIPTION
This PR adds rate limiting to the direct messaging endpoint (`POST /api/messages`) to mitigate potential spam and DoS attacks.

### 🎯 What:
- Implemented rate limiting on the `/api/messages` POST endpoint.
- Updated `API.md` to document the new rate limit.

### ⚠️ Risk:
- Previously, the endpoint had no rate limiting, allowing a malicious or buggy client to flood the system with messages.
- This could lead to resource exhaustion in the database and KV store, as well as an poor user experience for recipients.

### 🛡️ Solution:
- Integrated the existing `checkRateLimit` helper into the `/api/messages` handler.
- Configured a limit of 60 messages per 10 minutes (600 seconds) per IP address.
- Returns a `429 Too Many Requests` status code with the message "Sending messages too fast. Please wait." when the limit is exceeded.


---
*PR created automatically by Jules for task [14847679515136698485](https://jules.google.com/task/14847679515136698485) started by @thuruht*