### PR TITLE
🧹 [code health] remove unused upgradeWebSocket import from src/index.ts

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -2,7 +2,6 @@
 
 import { Hono } from 'hono';
 import { cors } from 'hono/cors';
-import { upgradeWebSocket } from 'hono/cloudflare-workers';
 import { sign, verify } from 'hono/jwt';
 import { setCookie, getCookie, deleteCookie } from 'hono/cookie';
 import { Resend } from 'resend';


### PR DESCRIPTION
Removed the unused import `upgradeWebSocket` from `src/index.ts`. Verified that it was not used anywhere in the file.

---
*PR created automatically by Jules for task [14650330611392749508](https://jules.google.com/task/14650330611392749508) started by @thuruht*