### PR TITLE
Resolve Merge Conflicts in Admin Broadcast and User Routes

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -12,4 +12,4 @@ export const RATE_LIMITS = {
   feedback: { limit: 3, window: 3600 },
   vitality: { limit: 10, window: 60 }
 };
-export const ADMIN_USER_ID = parseInt(process.env.ADMIN_USER_ID || '1');
+export const ADMIN_USER_ID = parseInt((typeof process !== 'undefined' && process.env && process.env.ADMIN_USER_ID) || '1');

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,6 +7,7 @@ import { sign, verify } from 'hono/jwt';
 import { setCookie, getCookie, deleteCookie } from 'hono/cookie';
 import { Resend } from 'resend';
 import JSZip from 'jszip';
+import { ADMIN_USER_ID } from './constants';
 
 // Import the Durable Object class (only for type inference, not for instantiation here)
 import { RelfDO } from './do';
@@ -36,8 +37,6 @@ interface Env {
 
 const app = new Hono<{ Bindings: Env, Variables: Variables }>();
 
-<<<<<<< ours
-=======
 // --- Authentication Middleware ---
 const authMiddleware = async (c: any, next: any) => {
   const token = getCookie(c, 'auth_token');
@@ -62,7 +61,6 @@ const authMiddleware = async (c: any, next: any) => {
   }
 };
 
->>>>>>> theirs
 // Document Collaboration WebSocket endpoint
 app.get('/api/collab/:fileId', authMiddleware, async (c) => {
   const upgradeHeader = c.req.header('Upgrade');
@@ -187,29 +185,6 @@ function getR2PublicUrl(c: any, r2_key: string): string {
     return `https://pub-${c.env.R2_BUCKET_NAME}.${c.env.R2_ACCOUNT_ID}.r2.dev/${r2_key}`;
 }
 
-// --- Authentication Middleware ---
-const authMiddleware = async (c: any, next: any) => {
-  const token = getCookie(c, 'auth_token');
-  if (!token) {
-    return c.json({ error: 'Unauthorized: No token provided' }, 401);
-  }
-
-  try {
-    const secret = c.env.JWT_SECRET || 'fallback_dev_secret_do_not_use_in_prod';
-    const payload = await verify(token, secret);
-
-    if (!payload || !payload.id) {
-      return c.json({ error: 'Unauthorized: Invalid token payload' }, 401);
-    }
-
-    // Attach user ID to context variables for downstream routes
-    c.set('user_id', payload.id as number);
-    await next();
-  } catch (e) {
-    console.error("JWT verification failed:", e);
-    return c.json({ error: 'Unauthorized: Invalid or expired token' }, 401);
-  }
-};
 
 // --- Auth Routes ---
 
@@ -451,41 +426,7 @@ app.get('/api/users/me', async (c) => {
 
     // Optional: Fetch fresh data from DB to ensure user still exists
     const user = await c.env.DB.prepare(
-<<<<<<< ours
-      'SELECT id, username, avatar_url, public_key, encrypted_private_key FROM users WHERE id = ?'
-=======
       'SELECT id, username, avatar_url, public_key, encrypted_private_key, role, is_lurking FROM users WHERE id = ?'
-<<<<<<< ours
-<<<<<<< ours
-<<<<<<< ours
-<<<<<<< ours
-<<<<<<< ours
-<<<<<<< ours
-<<<<<<< ours
-<<<<<<< ours
-<<<<<<< ours
-<<<<<<< ours
->>>>>>> theirs
-=======
->>>>>>> theirs
-=======
->>>>>>> theirs
-=======
->>>>>>> theirs
-=======
->>>>>>> theirs
-=======
->>>>>>> theirs
-=======
->>>>>>> theirs
-=======
->>>>>>> theirs
-=======
->>>>>>> theirs
-=======
->>>>>>> theirs
-=======
->>>>>>> theirs
     ).bind(payload.id).first();
 
     if (!user) return c.json({ error: 'User not found' }, 404);
@@ -501,38 +442,7 @@ app.get('/api/users/me', async (c) => {
     });
   } catch (e) {
     return c.json({ error: 'Invalid token' }, 401);
-<<<<<<< ours
-<<<<<<< ours
-<<<<<<< ours
-<<<<<<< ours
-<<<<<<< ours
-<<<<<<< ours
-<<<<<<< ours
-<<<<<<< ours
-<<<<<<< ours
-<<<<<<< ours
-<<<<<<< ours
-=======
-=======
->>>>>>> theirs
-=======
->>>>>>> theirs
-=======
->>>>>>> theirs
-=======
->>>>>>> theirs
-=======
->>>>>>> theirs
-=======
->>>>>>> theirs
-=======
->>>>>>> theirs
-=======
->>>>>>> theirs
-=======
->>>>>>> theirs
-=======
->>>>>>> theirs
+
   }
 });
 
@@ -554,7 +464,7 @@ app.put('/api/users/me/privacy', authMiddleware, async (c) => {
   } catch (e) {
     console.error("Error updating privacy:", e);
     return c.json({ error: 'Failed to update privacy settings' }, 500);
->>>>>>> theirs
+
   }
 });
 
@@ -640,7 +550,6 @@ app.put('/api/customization', authMiddleware, async (c) => {
   }
 });
 
-
 // Deprecated routes kept for backward compat if needed (redirecting logic internally)
 app.get('/api/users/me/preferences', authMiddleware, async (c) => {
     // Reuse new logic
@@ -708,7 +617,6 @@ app.use('/api/messages', authMiddleware); // Ensure root /api/messages is protec
 app.use('/api/messages/*', authMiddleware); // Added messages middleware
 app.use('/api/users/*', authMiddleware); // Ensure user routes are authenticated
 
-
 // Durable Object WebSocket endpoint
 app.get('/api/do-websocket', authMiddleware, async (c) => {
   const upgradeHeader = c.req.header('Upgrade');
@@ -734,20 +642,11 @@ app.get('/api/do-websocket', authMiddleware, async (c) => {
   }
 });
 
-
 // GET /api/admin/stats: System statistics (Admin only)
 app.get('/api/admin/stats', authMiddleware, async (c) => {
   const user_id = c.get('user_id');
-<<<<<<< ours
-<<<<<<< ours
-  // Simple admin check: assume user ID 1 is the admin
-  if (user_id !== 1) {
-=======
   if (user_id !== ADMIN_USER_ID) {
->>>>>>> theirs
-=======
-  if (user_id !== ADMIN_USER_ID) {
->>>>>>> theirs
+
     return c.json({ error: 'Unauthorized' }, 403);
   }
 
@@ -771,15 +670,7 @@ app.get('/api/admin/stats', authMiddleware, async (c) => {
 // GET /api/admin/users: List users (Admin only)
 app.get('/api/admin/users', authMiddleware, async (c) => {
   const user_id = c.get('user_id');
-<<<<<<< ours
-<<<<<<< ours
-  if (user_id !== 1) return c.json({ error: 'Unauthorized' }, 403);
-=======
   if (user_id !== ADMIN_USER_ID) return c.json({ error: 'Unauthorized' }, 403);
->>>>>>> theirs
-=======
-  if (user_id !== ADMIN_USER_ID) return c.json({ error: 'Unauthorized' }, 403);
->>>>>>> theirs
 
   try {
     const { results } = await c.env.DB.prepare(
@@ -794,18 +685,11 @@ app.get('/api/admin/users', authMiddleware, async (c) => {
 // DELETE /api/admin/users/:id: Delete user (Admin only)
 app.delete('/api/admin/users/:id', authMiddleware, async (c) => {
   const user_id = c.get('user_id');
-<<<<<<< ours
-<<<<<<< ours
-  if (user_id !== 1) return c.json({ error: 'Unauthorized' }, 403);
-=======
   if (user_id !== ADMIN_USER_ID) return c.json({ error: 'Unauthorized' }, 403);
->>>>>>> theirs
-=======
-  if (user_id !== ADMIN_USER_ID) return c.json({ error: 'Unauthorized' }, 403);
->>>>>>> theirs
+
   const targetId = Number(c.req.param('id'));
 
-  if (targetId === 1) return c.json({ error: 'Cannot delete admin' }, 400);
+  if (targetId === ADMIN_USER_ID) return c.json({ error: 'Cannot delete admin' }, 400);
 
   try {
     // Cascade delete manually if foreign keys aren't set
@@ -824,15 +708,7 @@ app.delete('/api/admin/users/:id', authMiddleware, async (c) => {
 // POST /api/admin/broadcast: System broadcast (Admin only)
 app.post('/api/admin/broadcast', authMiddleware, async (c) => {
   const user_id = c.get('user_id');
-<<<<<<< ours
-<<<<<<< ours
-  if (user_id !== 1) return c.json({ error: 'Unauthorized' }, 403);
-=======
   if (user_id !== ADMIN_USER_ID) return c.json({ error: 'Unauthorized' }, 403);
->>>>>>> theirs
-=======
-  if (user_id !== ADMIN_USER_ID) return c.json({ error: 'Unauthorized' }, 403);
->>>>>>> theirs
 
   const { message } = await c.req.json();
   if (!message) return c.json({ error: 'Message required' }, 400);
@@ -840,7 +716,7 @@ app.post('/api/admin/broadcast', authMiddleware, async (c) => {
   try {
       // 1. Create system notification for all users? Too expensive for DB.
       // Instead, just use WebSocket broadcast via DO
-      await broadcastSignal(c.env, 'system_alert', 1, { message });
+      await broadcastSignal(c.env, 'system_alert', ADMIN_USER_ID, { message });
       return c.json({ message: 'Broadcast sent' });
   } catch (e) {
       return c.json({ error: 'Broadcast failed' }, 500);
@@ -916,7 +792,6 @@ app.get('/api/users/:id', authMiddleware, async (c) => {
   }
 });
 
-
 // --- Notification Helpers ---
 
 async function createNotification(
@@ -952,7 +827,7 @@ async function createNotification(
 
 async function broadcastSignal(
   env: Env,
-  type: 'signal_communique' | 'signal_artifact',
+  type: 'signal_communique' | 'signal_artifact' | 'system_alert',
   userId: number,
   payload: any = {}
 ) {
@@ -1147,7 +1022,6 @@ app.post('/api/relationships/sym-request', authMiddleware, async (c) => {
     if (mutual) {
         return c.json({ error: 'Already have a mutual (sym) connection with this user' }, 409);
     }
-
 
     const { success } = await c.env.DB.prepare(
       'INSERT INTO relationships (source_user_id, target_user_id, type, status) VALUES (?, ?, ?, ?)'
@@ -1425,7 +1299,6 @@ app.get('/api/drift', authMiddleware, async (c) => {
     }
 });
 
-
 // --- Communique Routes ---
 
 // GET /api/communiques/:user_id: Fetch a user's communique
@@ -1495,7 +1368,6 @@ app.put('/api/communiques', async (c) => {
     return c.json({ error: 'Failed to update communique' }, 500);
   }
 });
-
 
 // --- Files Routes ---
 
@@ -1887,7 +1759,6 @@ app.delete('/api/files/:id', async (c) => {
   }
 });
 
-
 // POST /api/files/:id/refresh: Reset expiration timer (Keep Alive)
 app.post('/api/files/:id/refresh', async (c) => {
   const user_id = c.get('user_id');
@@ -2140,7 +2011,6 @@ app.put('/api/collections/:id/reorder', async (c) => {
   }
 });
 
-
 // DELETE /api/collections/:id: Delete collection
 app.delete('/api/collections/:id', async (c) => {
   const user_id = c.get('user_id');
@@ -2296,7 +2166,6 @@ app.delete('/api/collections/:id/files/:file_id', async (c) => {
     return c.json({ error: 'Failed to remove file from collection' }, 500);
   }
 });
-
 
 // --- Messaging Routes (Phase 9) ---
 
@@ -2459,7 +2328,6 @@ app.put('/api/messages/:partner_id/read', async (c) => {
   }
 });
 
-
 // POST /api/users/me/avatar: Upload user avatar to R2
 app.post('/api/users/me/avatar', async (c) => {
   const user_id = c.get('user_id');
@@ -2503,7 +2371,6 @@ app.post('/api/users/me/avatar', async (c) => {
     return c.json({ error: 'Avatar upload failed' }, 500);
   }
 });
-
 
 // POST /api/feedback: Send feedback to admin
 app.post('/api/feedback', async (c) => {


### PR DESCRIPTION
I have resolved the critical merge conflicts in `src/index.ts` that were causing syntax errors and breaking admin authorization logic. 

Key changes:
1.  **Resolved Merge Conflicts**: Removed all `<<<<<<<`, `=======`, and `>>>>>>>` markers from `src/index.ts`.
2.  **Environment-Safe Constants**: Updated `src/constants.ts` to safely check for the existence of the `process` object when defining `ADMIN_USER_ID`, ensuring compatibility with Cloudflare Workers.
3.  **Consistent Admin Authorization**: Replaced hardcoded admin IDs (e.g., `1`) with the `ADMIN_USER_ID` constant across all administrative endpoints (`/api/admin/stats`, `/api/admin/users`, and `/api/admin/broadcast`).
4.  **Middleware Cleanup**: Fixed the redundant and misplaced `authMiddleware` definitions resulting from the failed merge, and moved the definition before its first usage in route handlers.
5.  **Schema Alignment**: Updated the `/api/users/me` database query to fetch `role` and `is_lurking` fields, consistent with the intended application state.
6.  **Helper Type Update**: Expanded the `broadcastSignal` signal type to include `'system_alert'` to support the admin broadcast feature.

The code has been reviewed and verified for correctness.

---
*PR created automatically by Jules for task [1145310273653612369](https://jules.google.com/task/1145310273653612369) started by @thuruht*