### PR TITLE
🧪 Add unit tests for sanitizeHTML utility

### DIFF
--- a/client/src/utils/sanitize.test.ts
+++ b/client/src/utils/sanitize.test.ts
@@ -1,0 +1,60 @@
+import { test } from 'node:test';
+import assert from 'node:assert';
+import { sanitizeHTML } from './sanitize.ts';
+
+test('sanitizeHTML handles empty or null input', () => {
+  assert.strictEqual(sanitizeHTML(''), '');
+  // @ts-ignore
+  assert.strictEqual(sanitizeHTML(null), '');
+  // @ts-ignore
+  assert.strictEqual(sanitizeHTML(undefined), '');
+});
+
+test('sanitizeHTML removes script tags', () => {
+  const input = '<div>Hello <script>alert("xss")</script>world</div>';
+  const expected = '<div>Hello world</div>';
+  assert.strictEqual(sanitizeHTML(input), expected);
+});
+
+test('sanitizeHTML is case insensitive for script tags', () => {
+  const input = '<div>Hello <SCRIPT>alert("xss")</SCRIPT>world</div>';
+  const expected = '<div>Hello world</div>';
+  assert.strictEqual(sanitizeHTML(input), expected);
+});
+
+test('sanitizeHTML handles multiline script tags', () => {
+  const input = `<div>
+    <script>
+      console.log("malicious");
+    </script>
+    Safe content
+  </div>`;
+  const expected = `<div>
+
+    Safe content
+  </div>`;
+  assert.strictEqual(sanitizeHTML(input), expected);
+});
+
+test('sanitizeHTML removes event handlers', () => {
+  const input = '<button onclick="alert(\'xss\')" onmouseover="evil()">Click me</button>';
+  const expected = '<button>Click me</button>';
+  assert.strictEqual(sanitizeHTML(input), expected);
+});
+
+test('sanitizeHTML replaces javascript: links with #', () => {
+  const input = '<a href="javascript:alert(\'xss\')">Link</a>';
+  const expected = '<a href="#">Link</a>';
+  assert.strictEqual(sanitizeHTML(input), expected);
+});
+
+test('sanitizeHTML handles mixed malicious content', () => {
+  const input = '<div onmouseover="hide()"><script>bad()</script><a href="javascript:void(0)">Click</a></div>';
+  const expected = '<div><a href="#">Click</a></div>';
+  assert.strictEqual(sanitizeHTML(input), expected);
+});
+
+test('sanitizeHTML preserves safe HTML', () => {
+  const input = '<b>Bold</b> <i>Italic</i> <p>Paragraph</p>';
+  assert.strictEqual(sanitizeHTML(input), input);
+});

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "deploy": "npm run build:client && wrangler deploy --minify",
     "build:client": "vite build --outDir ../dist",
     "build": "npm run build:client",
-    "rollback": "wrangler deployments rollback"
+    "rollback": "wrangler deployments rollback",
+    "test": "node --test --experimental-strip-types \"client/src/**/*.test.ts\" \"src/**/*.test.ts\""
   },
   "dependencies": {
     "@codemirror/commands": "^6.10.1",


### PR DESCRIPTION
🎯 **What:** The testing gap for the `sanitizeHTML` utility function has been addressed by adding a comprehensive suite of unit tests.

📊 **Coverage:** The new tests cover:
- Empty, null, and undefined inputs.
- Removal of `<script>` tags (case-insensitive and multiline).
- Removal of HTML event handlers (e.g., `onclick`, `onmouseover`).
- Replacement of `javascript:` links with `#`.
- Preservation of safe HTML tags (e.g., `<b>`, `<i>`, `<p>`).
- Mixed malicious content scenarios.

✨ **Result:** Significant improvement in the reliability of the sanitization logic, ensuring that XSS prevention remains effective during future refactors. The project now has a standard way to run tests via `pnpm test`.

---
*PR created automatically by Jules for task [16927854128523827061](https://jules.google.com/task/16927854128523827061) started by @thuruht*