### PR TITLE
Refactor mobile menu for proper absolute positioning

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -355,7 +355,7 @@ function Main() {
                 </div>
 
                 {currentUser && (
-                <div style={{ display: 'flex', alignItems: 'center', gap: '15px' }}>
+                <div style={{ display: 'flex', alignItems: 'center', gap: '15px', position: 'relative' }}>
                     
                     <div className="desktop-only" style={{ display: 'flex', gap: '10px' }}>
                       <div style={{ display: 'flex', background: 'rgba(255,255,255,0.05)', borderRadius: '4px', padding: '2px', border: '1px solid var(--border-color)' }}>
@@ -418,25 +418,10 @@ function Main() {
                     <button onClick={() => setIsMenuOpen(!isMenuOpen)} style={{ padding: '8px' }} title="Menu" aria-label="Open menu">
                         {isMenuOpen ? <IconX size={20} aria-hidden="true" /> : <IconMenu2 size={20} aria-hidden="true" />}
                     </button>
-                </div>
-                )}
-                </div>
-            </div>
-    
-            {/* Dropdown Menu */}
-              {isMenuOpen && (
-                <div className="glass-panel nav-dropdown" style={{
-                  position: 'absolute',
-                  top: '60px',
-                  right: '10px',
-                  padding: '1rem',
-                  display: 'flex',
-                  flexDirection: 'column',
-                  gap: '1rem',
-                  zIndex: 2000,
-                  maxHeight: '80vh',
-                  overflowY: 'auto'
-                }}>
+
+                    {/* Dropdown Menu */}
+                    {isMenuOpen && (
+                        <div className="glass-panel nav-dropdown">
                     <div className="mobile-only" style={{ display: 'flex', flexDirection: 'column', gap: '12px', paddingBottom: '12px', borderBottom: '1px solid var(--border-color)' }}>
                         <SearchBar />
                         <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
@@ -511,6 +496,10 @@ function Main() {
                     </button>
                 </div>
             )}
+                </div>
+                )}
+                </div>
+            </div>
     
             {isFAQOpen && <FAQ onClose={() => setIsFAQOpen(false)} />}
             {isAboutOpen && <About onClose={() => setIsAboutOpen(false)} />}

--- a/client/src/styles/global.css
+++ b/client/src/styles/global.css
@@ -163,11 +163,20 @@ input:focus, textarea:focus {
   color: var(--text-primary);
 }
 
-/* Mobile Menu Fix */
+/* Mobile Menu */
 .nav-dropdown {
-  right: 1rem !important; /* Force right alignment */
-  left: auto !important;
-  max-width: 90vw; /* Prevent overflow */
+  position: absolute;
+  top: 60px;
+  right: 10px;
+  left: auto;
+  padding: 1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  z-index: var(--z-dropdown);
+  max-height: 80vh;
+  overflow-y: auto;
+  max-width: 90vw;
   width: 250px;
 }
 


### PR DESCRIPTION
This change refactors the mobile menu implementation by improving its HTML/React structure and consolidating its styling. Previously, the menu relied on `!important` CSS overrides and hardcoded inline styles. By nesting the menu within a `position: relative` container in `App.tsx` and migrating all style properties to the `.nav-dropdown` class in `global.css`, we establish a clean, maintainable absolute positioning context that follows the application's design patterns.

---
*PR created automatically by Jules for task [16418212225832554602](https://jules.google.com/task/16418212225832554602) started by @thuruht*