### PR TITLE
🧹 [Code Health] Remove 'any' types from drift data in `useNetworkData.ts`

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -19,7 +19,7 @@ import FilePreviewModal from './components/FilePreviewModal';
 import { ThemeProvider, useTheme } from './context/ThemeContext';
 import { CustomizationProvider } from './context/CustomizationContext';
 import { ToastProvider, useToast } from './context/ToastContext';
-import { useNetworkData } from './hooks/useNetworkData';
+import { useNetworkData, DriftData } from './hooks/useNetworkData';
 import { SearchBar, RandomUserButton } from './components/UserDiscovery';
 import AmbientBackground from './components/AmbientBackground';
 
@@ -43,7 +43,7 @@ function Main() {
   const [loadingUser, setLoadingUser] = useState(true);
   const [isDrifting, setIsDrifting] = useState(false);
   const [driftType, setDriftType] = useState<string>(''); // '' = all, 'image', 'audio', 'text'
-  const [driftData, setDriftData] = useState<{users: any[], files: any[]}>({ users: [], files: [] });
+  const [driftData, setDriftData] = useState<DriftData>({ users: [], files: [] });
   const [viewMode, setViewMode] = useState<'graph' | 'list'>('graph');
   const [isMenuOpen, setIsMenuOpen] = useState(false);
   const [unreadCount, setUnreadCount] = useState(0);

--- a/client/src/hooks/useNetworkData.ts
+++ b/client/src/hooks/useNetworkData.ts
@@ -22,12 +22,31 @@ export interface NetworkCollection {
     file_ids: number[];
 }
 
+export interface DriftUser {
+  id: number;
+  username: string;
+  avatar_url?: string;
+}
+
+export interface DriftFile {
+  id: number;
+  filename: string;
+  mime_type: string;
+  user_id: number;
+  owner_username: string;
+}
+
+export interface DriftData {
+  users: DriftUser[];
+  files: DriftFile[];
+}
+
 interface UseNetworkDataProps {
   currentUserId: number | null;
   meUsername: string | undefined; 
   meAvatarUrl: string | undefined; 
   isDrifting: boolean;
-  driftData: { users: any[], files: any[] };
+  driftData: DriftData;
   onlineUserIds: Set<number>;
 }
 
@@ -127,7 +146,7 @@ export const useNetworkData = ({ currentUserId, meUsername, meAvatarUrl, isDrift
 
       // Drift Logic
       if (isDrifting && driftData) {
-        driftData.users?.forEach((u: any) => {
+        driftData.users?.forEach((u: DriftUser) => {
           const uid = u.id.toString();
           if (!nodeMap.has(uid)) {
             nodeMap.set(uid, {
@@ -140,7 +159,7 @@ export const useNetworkData = ({ currentUserId, meUsername, meAvatarUrl, isDrift
           }
         });
 
-        driftData.files?.forEach((f: any) => {
+        driftData.files?.forEach((f: DriftFile) => {
             const fileNodeId = `file-${f.id}`;
             const ownerId = f.user_id.toString();
 


### PR DESCRIPTION
🎯 **What:** Removed the use of `any` types for `driftData` (both `users` and `files` arrays).
💡 **Why:** To improve code health, safety, and readability by having explicit interfaces (`DriftUser`, `DriftFile`, `DriftData`) that map to what the API `/api/drift` actually returns. 
✅ **Verification:** Verified by checking types locally and running a successful `pnpm run build:client` build to ensure zero compilation or type errors. 
✨ **Result:** Types are strictly defined, replacing generic `any` usage.

---
*PR created automatically by Jules for task [6846484156285138794](https://jules.google.com/task/6846484156285138794) started by @thuruht*