### PR TITLE
🔒 Remove hardcoded JWT secret fallback

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -49,7 +49,11 @@ const authMiddleware = async (c: any, next: any) => {
   }
 
   try {
-    const secret = c.env.JWT_SECRET || 'fallback_dev_secret_do_not_use_in_prod';
+    if (!c.env.JWT_SECRET) {
+      console.error("Critical: JWT_SECRET is not configured in environment variables.");
+      return c.json({ error: 'Internal Server Error: Authentication misconfigured' }, 500);
+    }
+    const secret = c.env.JWT_SECRET;
     const payload = await verify(token, secret);
 
     if (!payload || !payload.id) {
@@ -245,7 +249,11 @@ const authMiddleware = async (c: any, next: any) => {
   }
 
   try {
-    const secret = c.env.JWT_SECRET || 'fallback_dev_secret_do_not_use_in_prod';
+    if (!c.env.JWT_SECRET) {
+      console.error("Critical: JWT_SECRET is not configured in environment variables.");
+      return c.json({ error: 'Internal Server Error: Authentication misconfigured' }, 500);
+    }
+    const secret = c.env.JWT_SECRET;
     const payload = await verify(token, secret);
 
     if (!payload || !payload.id) {
@@ -496,7 +504,11 @@ app.get('/api/users/me', async (c) => {
   if (!token) return c.json({ error: 'Unauthorized' }, 401);
 
   try {
-    const secret = c.env.JWT_SECRET || 'fallback_dev_secret_do_not_use_in_prod';
+    if (!c.env.JWT_SECRET) {
+      console.error("Critical: JWT_SECRET is not configured in environment variables.");
+      return c.json({ error: 'Internal Server Error' }, 500);
+    }
+    const secret = c.env.JWT_SECRET;
     const payload = await verify(token, secret);
 
     // Optional: Fetch fresh data from DB to ensure user still exists


### PR DESCRIPTION
🎯 **What:** The vulnerability fixed
This PR removes a hardcoded JWT secret fallback (`'fallback_dev_secret_do_not_use_in_prod'`) from the codebase, replacing it with a secure fail-closed mechanism. If the `JWT_SECRET` environment variable is not configured, the affected endpoints and middleware now return a 500 Internal Server Error instead of proceeding.

⚠️ **Risk:** The potential impact if left unfixed
If the application is inadvertently deployed without a `JWT_SECRET` configured, it would fall back to using a known, hardcoded string. An attacker aware of this could easily forge valid JWT tokens, gaining unauthorized access to any user account or privileged functionality, leading to a complete compromise of the system.

🛡️ **Solution:** How the fix addresses the vulnerability
The fix removes the hardcoded string entirely. In places where it was used (`authMiddleware` and `GET /api/users/me`), explicit checks for `c.env.JWT_SECRET` were added. If the secret is missing, an error is logged to the server console and a 500 Internal Server Error is immediately returned to the client, effectively preventing the application from running in an insecure state.

---
*PR created automatically by Jules for task [15566241362756644056](https://jules.google.com/task/15566241362756644056) started by @thuruht*