### PR TITLE
Refactor FilePreviewModal collaboration state & resolve src/index.ts merge conflicts

### DIFF
--- a/client/src/components/CollaborativeCodeEditor.tsx
+++ b/client/src/components/CollaborativeCodeEditor.tsx
@@ -1,0 +1,95 @@
+import React, { useState, useEffect } from 'react';
+import * as Y from 'yjs';
+import { WebsocketProvider } from 'y-websocket';
+import CodeEditor from './CodeEditor';
+
+interface CollaborativeCodeEditorProps {
+  fileId: string;
+  currentUser?: any;
+  themePreferences: any;
+  initialContent: string;
+  filename: string;
+  onChange: (val: string) => void;
+  onStatusChange: (status: 'disconnected' | 'connecting' | 'connected') => void;
+  onUsersChange: (users: any[]) => void;
+}
+
+const CollaborativeCodeEditor: React.FC<CollaborativeCodeEditorProps> = ({
+  fileId,
+  currentUser,
+  themePreferences,
+  initialContent,
+  filename,
+  onChange,
+  onStatusChange,
+  onUsersChange
+}) => {
+  const [ydoc, setYdoc] = useState<Y.Doc | null>(null);
+  const [provider, setProvider] = useState<WebsocketProvider | null>(null);
+
+  useEffect(() => {
+    let currentProvider: WebsocketProvider | null = null;
+    let currentDoc: Y.Doc | null = null;
+
+    onStatusChange('connecting');
+    const doc = new Y.Doc();
+    const wsUrl = window.location.protocol === 'https:' ? `wss://${window.location.host}` : `ws://${window.location.host}`;
+
+    const prov = new WebsocketProvider(`${wsUrl}/api/collab/${fileId}`, '', doc);
+
+    const userColor = themePreferences.node_primary_color || '#' + Math.floor(Math.random()*16777215).toString(16);
+    prov.awareness.setLocalStateField('user', {
+      name: currentUser?.username || 'Anonymous',
+      color: userColor,
+      id: currentUser?.id
+    });
+
+    prov.awareness.on('change', () => {
+      const states = Array.from(prov.awareness.getStates().values());
+      const users = states.map((s: any) => s.user).filter((u: any) => u);
+      onUsersChange(users);
+    });
+
+    prov.on('status', (event: { status: 'disconnected' | 'connecting' | 'connected' }) => {
+      onStatusChange(event.status);
+    });
+
+    const yText = doc.getText('codemirror');
+
+    if (initialContent && yText.length === 0) {
+      yText.insert(0, initialContent);
+    }
+
+    if (yText.toString() === '' && initialContent !== '') {
+      yText.insert(0, initialContent);
+    }
+
+    yText.observe(() => {
+      onChange(yText.toString());
+    });
+
+    setYdoc(doc);
+    setProvider(prov);
+    currentProvider = prov;
+    currentDoc = doc;
+
+    return () => {
+      onStatusChange('disconnected');
+      onUsersChange([]);
+      if (currentProvider) currentProvider.destroy();
+      if (currentDoc) currentDoc.destroy();
+    };
+  }, [fileId]);
+
+  return (
+    <CodeEditor
+      content={initialContent}
+      onChange={onChange}
+      filename={filename}
+      ydoc={ydoc}
+      provider={provider}
+    />
+  );
+};
+
+export default CollaborativeCodeEditor;

--- a/client/src/components/FilePreviewModal.tsx
+++ b/client/src/components/FilePreviewModal.tsx
@@ -5,9 +5,8 @@ import Skeleton from './Skeleton';
 import { useToast } from '../context/ToastContext';
 import CollectionsManager from './CollectionsManager';
 import CodeEditor from './CodeEditor';
+import CollaborativeCodeEditor from './CollaborativeCodeEditor';
 import { useCustomization } from '../context/CustomizationContext';
-import * as Y from 'yjs';
-import { WebsocketProvider } from 'y-websocket';
 import { useCollections } from '../hooks/useCollections';
 import UploadModal from './UploadModal';
 
@@ -39,10 +38,7 @@ const FilePreviewModal: React.FC<FilePreviewModalProps> = ({ fileId, onClose, cu
   // Use the hook from main branch instead of the hacky component usage
   const { addToCollection } = useCollections();
 
-  // Collaboration State - Using useState for re-rendering CodeEditor (Fix from mobile-fixes branch)
   const [collabStatus, setCollabStatus] = useState<'disconnected' | 'connecting' | 'connected'>('disconnected');
-  const [ydoc, setYdoc] = useState<Y.Doc | null>(null);
-  const [provider, setProvider] = useState<WebsocketProvider | null>(null);
   const [connectedUsers, setConnectedUsers] = useState<any[]>([]);
 
   const { theme_preferences, updateCustomization } = useCustomization();
@@ -226,73 +222,6 @@ const FilePreviewModal: React.FC<FilePreviewModalProps> = ({ fileId, onClose, cu
           showToast('Vote failed', 'error');
       }
   };
-
-  // --- Collab Setup ---
-  useEffect(() => {
-    let currentProvider: WebsocketProvider | null = null;
-    let currentDoc: Y.Doc | null = null;
-
-    if (isEditing && isText) {
-       // Initialize Yjs
-       setCollabStatus('connecting');
-       const doc = new Y.Doc();
-       const wsUrl = window.location.protocol === 'https:' ? `wss://${window.location.host}` : `ws://${window.location.host}`;
-
-       // Note: In real production, authentication token should be passed here
-       const prov = new WebsocketProvider(`${wsUrl}/api/collab/${fileId}`, '', doc);
-
-       // Set Awareness
-       const userColor = theme_preferences.node_primary_color || '#' + Math.floor(Math.random()*16777215).toString(16);
-       prov.awareness.setLocalStateField('user', {
-           name: currentUser?.username || 'Anonymous',
-           color: userColor,
-           id: currentUser?.id
-       });
-
-       prov.awareness.on('change', () => {
-           const states = Array.from(prov.awareness.getStates().values());
-           const users = states.map((s: any) => s.user).filter((u: any) => u);
-           setConnectedUsers(users);
-       });
-
-       prov.on('status', (event: any) => {
-         setCollabStatus(event.status); // 'connected' or 'disconnected'
-       });
-
-       const yText = doc.getText('codemirror'); // Standard Yjs text type name
-
-       // Initial sync: set local content to Yjs doc if empty
-       // Ensure we don't overwrite if data exists (naive check)
-       if (editContent && yText.length === 0) {
-           yText.insert(0, editContent);
-       }
-       
-       // Force sync just in case
-       if (yText.toString() === '' && editContent !== '') {
-           yText.insert(0, editContent);
-       }
-
-       // Observe changes from other peers
-       yText.observe(event => {
-           setEditContent(yText.toString());
-       });
-
-       setYdoc(doc);
-       setProvider(prov);
-       currentProvider = prov;
-       currentDoc = doc;
-
-    } else {
-        setCollabStatus('disconnected');
-        setYdoc(null);
-        setProvider(null);
-    }
-
-    return () => {
-        if (currentProvider) currentProvider.destroy();
-        if (currentDoc) currentDoc.destroy();
-    };
-  }, [isEditing, isText, fileId]); // Removed editContent from dep array to avoid loops, handled inside
 
   const isMobile = window.innerWidth < 768;
 
@@ -551,12 +480,15 @@ const FilePreviewModal: React.FC<FilePreviewModalProps> = ({ fileId, onClose, cu
                    />
                )}
                {isText && isEditing && (
-                   <CodeEditor
-                     content={editContent}
-                     onChange={(val) => setEditContent(val)}
+                   <CollaborativeCodeEditor
+                     fileId={fileId!}
+                     currentUser={currentUser}
+                     themePreferences={theme_preferences}
+                     initialContent={editContent}
                      filename={filename}
-                     ydoc={ydoc}
-                     provider={provider}
+                     onChange={(val) => setEditContent(val)}
+                     onStatusChange={setCollabStatus}
+                     onUsersChange={setConnectedUsers}
                    />
                )}
              </>

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,4 @@
+import { ADMIN_USER_ID } from './constants';
 // index.ts
 
 import { Hono } from 'hono';
@@ -39,8 +40,6 @@ interface Env {
 
 const app = new Hono<{ Bindings: Env, Variables: Variables }>();
 
-<<<<<<< ours
-=======
 // --- Authentication Middleware ---
 const authMiddleware = async (c: any, next: any) => {
   const token = getCookie(c, 'auth_token');
@@ -65,7 +64,6 @@ const authMiddleware = async (c: any, next: any) => {
   }
 };
 
->>>>>>> theirs
 // Document Collaboration WebSocket endpoint
 app.get('/api/collab/:fileId', authMiddleware, async (c) => {
   const upgradeHeader = c.req.header('Upgrade');
@@ -237,29 +235,6 @@ function getR2PublicUrl(c: any, r2_key: string): string {
     return `https://pub-${c.env.R2_BUCKET_NAME}.${c.env.R2_ACCOUNT_ID}.r2.dev/${r2_key}`;
 }
 
-// --- Authentication Middleware ---
-const authMiddleware = async (c: any, next: any) => {
-  const token = getCookie(c, 'auth_token');
-  if (!token) {
-    return c.json({ error: 'Unauthorized: No token provided' }, 401);
-  }
-
-  try {
-    const secret = c.env.JWT_SECRET || 'fallback_dev_secret_do_not_use_in_prod';
-    const payload = await verify(token, secret);
-
-    if (!payload || !payload.id) {
-      return c.json({ error: 'Unauthorized: Invalid token payload' }, 401);
-    }
-
-    // Attach user ID to context variables for downstream routes
-    c.set('user_id', payload.id as number);
-    await next();
-  } catch (e) {
-    console.error("JWT verification failed:", e);
-    return c.json({ error: 'Unauthorized: Invalid or expired token' }, 401);
-  }
-};
 
 // --- Auth Routes ---
 
@@ -501,41 +476,7 @@ app.get('/api/users/me', async (c) => {
 
     // Optional: Fetch fresh data from DB to ensure user still exists
     const user = await c.env.DB.prepare(
-<<<<<<< ours
-      'SELECT id, username, avatar_url, public_key, encrypted_private_key FROM users WHERE id = ?'
-=======
       'SELECT id, username, avatar_url, public_key, encrypted_private_key, role, is_lurking FROM users WHERE id = ?'
-<<<<<<< ours
-<<<<<<< ours
-<<<<<<< ours
-<<<<<<< ours
-<<<<<<< ours
-<<<<<<< ours
-<<<<<<< ours
-<<<<<<< ours
-<<<<<<< ours
-<<<<<<< ours
->>>>>>> theirs
-=======
->>>>>>> theirs
-=======
->>>>>>> theirs
-=======
->>>>>>> theirs
-=======
->>>>>>> theirs
-=======
->>>>>>> theirs
-=======
->>>>>>> theirs
-=======
->>>>>>> theirs
-=======
->>>>>>> theirs
-=======
->>>>>>> theirs
-=======
->>>>>>> theirs
     ).bind(payload.id).first();
 
     if (!user) return c.json({ error: 'User not found' }, 404);
@@ -551,38 +492,6 @@ app.get('/api/users/me', async (c) => {
     });
   } catch (e) {
     return c.json({ error: 'Invalid token' }, 401);
-<<<<<<< ours
-<<<<<<< ours
-<<<<<<< ours
-<<<<<<< ours
-<<<<<<< ours
-<<<<<<< ours
-<<<<<<< ours
-<<<<<<< ours
-<<<<<<< ours
-<<<<<<< ours
-<<<<<<< ours
-=======
-=======
->>>>>>> theirs
-=======
->>>>>>> theirs
-=======
->>>>>>> theirs
-=======
->>>>>>> theirs
-=======
->>>>>>> theirs
-=======
->>>>>>> theirs
-=======
->>>>>>> theirs
-=======
->>>>>>> theirs
-=======
->>>>>>> theirs
-=======
->>>>>>> theirs
   }
 });
 
@@ -604,7 +513,6 @@ app.put('/api/users/me/privacy', authMiddleware, async (c) => {
   } catch (e) {
     console.error("Error updating privacy:", e);
     return c.json({ error: 'Failed to update privacy settings' }, 500);
->>>>>>> theirs
   }
 });
 
@@ -788,16 +696,7 @@ app.get('/api/do-websocket', authMiddleware, async (c) => {
 // GET /api/admin/stats: System statistics (Admin only)
 app.get('/api/admin/stats', authMiddleware, async (c) => {
   const user_id = c.get('user_id');
-<<<<<<< ours
-<<<<<<< ours
-  // Simple admin check: assume user ID 1 is the admin
-  if (user_id !== 1) {
-=======
   if (user_id !== ADMIN_USER_ID) {
->>>>>>> theirs
-=======
-  if (user_id !== ADMIN_USER_ID) {
->>>>>>> theirs
     return c.json({ error: 'Unauthorized' }, 403);
   }
 
@@ -821,15 +720,7 @@ app.get('/api/admin/stats', authMiddleware, async (c) => {
 // GET /api/admin/users: List users (Admin only)
 app.get('/api/admin/users', authMiddleware, async (c) => {
   const user_id = c.get('user_id');
-<<<<<<< ours
-<<<<<<< ours
-  if (user_id !== 1) return c.json({ error: 'Unauthorized' }, 403);
-=======
   if (user_id !== ADMIN_USER_ID) return c.json({ error: 'Unauthorized' }, 403);
->>>>>>> theirs
-=======
-  if (user_id !== ADMIN_USER_ID) return c.json({ error: 'Unauthorized' }, 403);
->>>>>>> theirs
 
   try {
     const { results } = await c.env.DB.prepare(
@@ -844,15 +735,7 @@ app.get('/api/admin/users', authMiddleware, async (c) => {
 // DELETE /api/admin/users/:id: Delete user (Admin only)
 app.delete('/api/admin/users/:id', authMiddleware, async (c) => {
   const user_id = c.get('user_id');
-<<<<<<< ours
-<<<<<<< ours
-  if (user_id !== 1) return c.json({ error: 'Unauthorized' }, 403);
-=======
   if (user_id !== ADMIN_USER_ID) return c.json({ error: 'Unauthorized' }, 403);
->>>>>>> theirs
-=======
-  if (user_id !== ADMIN_USER_ID) return c.json({ error: 'Unauthorized' }, 403);
->>>>>>> theirs
   const targetId = Number(c.req.param('id'));
 
   if (targetId === 1) return c.json({ error: 'Cannot delete admin' }, 400);
@@ -874,15 +757,7 @@ app.delete('/api/admin/users/:id', authMiddleware, async (c) => {
 // POST /api/admin/broadcast: System broadcast (Admin only)
 app.post('/api/admin/broadcast', authMiddleware, async (c) => {
   const user_id = c.get('user_id');
-<<<<<<< ours
-<<<<<<< ours
-  if (user_id !== 1) return c.json({ error: 'Unauthorized' }, 403);
-=======
   if (user_id !== ADMIN_USER_ID) return c.json({ error: 'Unauthorized' }, 403);
->>>>>>> theirs
-=======
-  if (user_id !== ADMIN_USER_ID) return c.json({ error: 'Unauthorized' }, 403);
->>>>>>> theirs
 
   const { message } = await c.req.json();
   if (!message) return c.json({ error: 'Message required' }, 400);
@@ -1002,7 +877,7 @@ async function createNotification(
 
 async function broadcastSignal(
   env: Env,
-  type: 'signal_communique' | 'signal_artifact',
+  type: 'signal_communique' | 'signal_artifact' | 'system_alert',
   userId: number,
   payload: any = {}
 ) {


### PR DESCRIPTION
Extracted the complex Yjs setup and WebsocketProvider state from `FilePreviewModal.tsx` into a new `CollaborativeCodeEditor` component, addressing the 'Fix from mobile-fixes branch' code comment. This significantly cleans up the modal's internal logic. Additionally, resolved severe pre-existing git merge conflict markers that were erroneously merged into the `main` branch inside `src/index.ts` (affecting `authMiddleware` and several admin routes), which was completely breaking backend builds. Verified the new CollaborativeCodeEditor locally using a headless Playwright script against an isolated Vite dev server.

---
*PR created automatically by Jules for task [1034478837039921408](https://jules.google.com/task/1034478837039921408) started by @thuruht*