### PR TITLE
Fix overlapping side drawers and stuck planets UI

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -60,6 +60,20 @@ function Main() {
   const [driftData, setDriftData] = useState<{ users: any[]; files: any[]; collections: any[] }>({ users: [], files: [], collections: [] });
   const [viewMode, setViewMode] = useState<'graph' | 'list'>('graph');
   const [isMenuOpen, setIsMenuOpen] = useState(false);
+
+  const closeAllDrawers = () => {
+    setIsInboxOpen(false);
+    setIsPlanetsOpen(false);
+    setIsGlobalChatOpen(false);
+    setIsArchiveOpen(false);
+    setIsFAQOpen(false);
+    setIsAboutOpen(false);
+    setIsAdminOpen(false);
+    setIsCollectionsOpen(false);
+    setIsFeedbackOpen(false);
+    setIsSettingsOpen(false);
+    setIsMenuOpen(false);
+  };
   const menuRef = useRef<HTMLDivElement>(null);
   const [unreadCount, setUnreadCount] = useState(0);
   const [groupUnreadCount, setGroupUnreadCount] = useState(0);
@@ -396,7 +410,7 @@ function Main() {
           <div className="header glass-panel" style={{ background: 'var(--header-bg-transparent)' }}>
             <div className="header-content">
               <div className="header-left">
-                <h2 className="header-logo" onClick={() => navigate('/')}>REL F <span className="header-logo-beta">BETA</span></h2>
+                <h2 className="header-logo" onClick={() => { closeAllDrawers(); navigate('/'); }}>REL F <span className="header-logo-beta">BETA</span></h2>
                 <div className="desktop-only" style={{ display: 'flex', gap: 'var(--spacing-md)' }}>
                   <SearchBar />
                   <RandomUserButton />
@@ -426,20 +440,20 @@ function Main() {
                         </button>
                       )}
                     </div>
-                    <button onClick={() => { setIsInboxOpen(!isInboxOpen); setUnreadCount(0); }} className="nav-button" aria-label={`Inbox, ${unreadCount} unread`}>
+                    <button onClick={() => { const wasOpen = isInboxOpen; closeAllDrawers(); setIsInboxOpen(!wasOpen); setUnreadCount(0); }} className="nav-button" aria-label={`Inbox, ${unreadCount} unread`}>
                       {"< mail >"}
                       {unreadCount > 0 && <span className="unread-badge" aria-hidden="true"></span>}
                     </button>
-                    <button onClick={() => setIsPlanetsOpen(!isPlanetsOpen)} className="nav-button" aria-label="Planets">
+                    <button onClick={() => { const wasOpen = isPlanetsOpen; closeAllDrawers(); setIsPlanetsOpen(!wasOpen); }} className="nav-button" aria-label="Planets">
                       {"< planets >"}
                       {groupUnreadCount > 0 && <span className="unread-badge" aria-hidden="true"></span>}
                     </button>
-                    <button onClick={() => setIsGlobalChatOpen(!isGlobalChatOpen)} className="nav-button" aria-label="Global Chat">
+                    <button onClick={() => { const wasOpen = isGlobalChatOpen; closeAllDrawers(); setIsGlobalChatOpen(!wasOpen); }} className="nav-button" aria-label="Global Chat">
                       {"< galaxy >"}
                     </button>
                   </div>
                   {/* Mobile: inbox badge button */}
-                  <button className="mobile-only nav-button" onClick={() => { setIsInboxOpen(!isInboxOpen); setUnreadCount(0); }} aria-label={`Inbox, ${unreadCount} unread`}>
+                  <button className="mobile-only nav-button" onClick={() => { const wasOpen = isInboxOpen; closeAllDrawers(); setIsInboxOpen(!wasOpen); setUnreadCount(0); }} aria-label={`Inbox, ${unreadCount} unread`}>
                     <TablerIcons.IconMessage size={ICON_SIZES.xl} aria-hidden="true" />
                     {unreadCount > 0 && <span className="unread-badge" aria-hidden="true"></span>}
                   </button>
@@ -476,19 +490,19 @@ function Main() {
               <button onClick={() => { navigate(`/communique/${currentUser?.id}`); setIsMenuOpen(false); }} className="menu-item">
                 <TablerIcons.IconUser size={ICON_SIZES.lg} /> My Cache (R3C)
               </button>
-              <button onClick={() => { setIsArchiveOpen(true); setIsMenuOpen(false); }} className="menu-item">
+              <button onClick={() => { closeAllDrawers(); setIsArchiveOpen(true); }} className="menu-item">
                 <TablerIcons.IconChartCircles size={ICON_SIZES.lg} /> Community Archive
               </button>
-              <button onClick={() => { setIsCollectionsOpen(true); setIsMenuOpen(false); }} className="menu-item">
+              <button onClick={() => { closeAllDrawers(); setIsCollectionsOpen(true); }} className="menu-item">
                 <TablerIcons.IconFolder size={ICON_SIZES.lg} /> Collections
               </button>
-              <button onClick={() => { setIsInboxOpen(true); setUnreadCount(0); setIsPlanetsOpen(false); setIsMenuOpen(false); }} className="menu-item">
+              <button onClick={() => { closeAllDrawers(); setIsInboxOpen(true); setUnreadCount(0); }} className="menu-item">
                 <TablerIcons.IconMessage size={ICON_SIZES.lg} /> {"< mail >"} {unreadCount > 0 && <span style={{ fontSize: '0.7em', background: 'var(--accent-alert)', padding: '0 5px', borderRadius: '4px', color: '#000', marginLeft: '4px' }}>{unreadCount}</span>}
               </button>
-              <button onClick={() => { setIsPlanetsOpen(true); setIsInboxOpen(false); setIsMenuOpen(false); }} className="menu-item">
+              <button onClick={() => { closeAllDrawers(); setIsPlanetsOpen(true); }} className="menu-item">
                 <TablerIcons.IconPlanet size={ICON_SIZES.lg} /> {"< planets >"} {groupUnreadCount > 0 && <span style={{ fontSize: '0.7em', background: 'var(--accent-alert)', padding: '0 5px', borderRadius: '4px', color: '#000', marginLeft: '4px' }}>{groupUnreadCount}</span>}
               </button>
-              <button onClick={() => { setIsGlobalChatOpen(true); setIsMenuOpen(false); }} className="menu-item">
+              <button onClick={() => { closeAllDrawers(); setIsGlobalChatOpen(true); }} className="menu-item">
                 <TablerIcons.IconBroadcast size={ICON_SIZES.lg} /> {"< galaxy >"}
               </button>
               <button onClick={() => { toggleTheme(); setIsMenuOpen(false); }} className="menu-item">

--- a/client/src/components/CustomizationSettings.tsx
+++ b/client/src/components/CustomizationSettings.tsx
@@ -141,8 +141,6 @@ return (
     position: 'absolute',
     bottom: 'calc(60px + var(--safe-area-bottom))',
     left: isMobile ? '10px' : '20px',
-...
-
       right: isMobile ? '10px' : 'auto',
       width: isMobile ? 'auto' : 'min(300px, calc(100vw - 40px))',
       maxHeight: 'min(80vh, calc(100vh - 130px))',

--- a/client/src/components/GroupChat.tsx
+++ b/client/src/components/GroupChat.tsx
@@ -359,12 +359,9 @@ const GroupChat: React.FC<GroupChatProps> = ({ onClose, currentUserId, ws }) => 
   const isAdmin = members.find(m => m.user_id === currentUserId)?.role === 'admin';
 
   return (
-    <div ref={panelRef} className="inbox-overlay fade-in" style={{
-      position: 'fixed', top: 'var(--header-height)', right: '10px', width: 'min(360px, 95vw)',
-      background: 'var(--drawer-bg)', border: '1px solid var(--border-color)',
-      backdropFilter: 'blur(10px)', padding: '0', borderRadius: '8px',
-      zIndex: 'var(--z-modal)', height: 'calc(100vh - var(--header-height) - 20px)', maxHeight: '800px', display: 'flex', flexDirection: 'column',
-      boxShadow: '0 10px 30px rgba(0,0,0,0.5)'
+    <div ref={panelRef} className="group-chat-container fade-in" style={{
+      display: 'flex', flexDirection: 'column', height: '100%',
+      paddingBottom: 'env(safe-area-inset-bottom, 0px)'
     }}>
       {/* Header */}
       <div style={{ display: 'flex', borderBottom: '1px solid var(--border-color)', padding: '10px 15px', alignItems: 'center', justifyContent: 'space-between' }}>

--- a/client/src/components/WorkspacesManager.tsx
+++ b/client/src/components/WorkspacesManager.tsx
@@ -217,7 +217,7 @@ const WorkspacesManager: React.FC<WorkspacesManagerProps> = ({ onClose }) => {
   };
 
   return (
-    <Modal isOpen={true} onClose={onClose} title="Collaborative Workspaces">
+    <div className="workspaces-container" style={{ display: "flex", flexDirection: "column", height: "100%" }}>
       <div style={{ 
           minHeight: '400px', 
           display: 'flex', 
@@ -420,7 +420,7 @@ const WorkspacesManager: React.FC<WorkspacesManagerProps> = ({ onClose }) => {
           }}
         />
       )}
-    </Modal>
+    </div>
   );
 };
 

--- a/client/src/hooks/useNetworkData.ts
+++ b/client/src/hooks/useNetworkData.ts
@@ -225,6 +225,3 @@ export const useNetworkData = ({ currentUserId, meUsername, meAvatarUrl, isDrift
     refresh: () => { setFileOffset(0); fetchData(false); } 
   };
 };
-
-  return { nodes, links, collections, loading, refresh: fetchData };
-};

--- a/fix.py
+++ b/fix.py
@@ -1,0 +1,16 @@
+with open("client/src/hooks/useNetworkData.ts", "r") as f:
+    lines = f.readlines()
+
+if "  return { nodes, links, collections, loading, refresh: fetchData };\n" in lines[-3:]:
+    lines = lines[:-3]
+elif "  return { nodes, links, collections, loading, refresh: fetchData };\n" in lines[-2:]:
+    lines = lines[:-2]
+else:
+    # Just trim trailing
+    while lines[-1].strip() == "};" or lines[-1].strip() == "return { nodes, links, collections, loading, refresh: fetchData };":
+        lines.pop()
+    if lines[-1].strip() == "return { nodes, links, collections, loading, refresh: fetchData };":
+        lines.pop()
+
+with open("client/src/hooks/useNetworkData.ts", "w") as f:
+    f.writelines(lines)

--- a/fix2.py
+++ b/fix2.py
@@ -1,0 +1,7 @@
+with open("client/src/components/CustomizationSettings.tsx", "r") as f:
+    content = f.read()
+
+content = content.replace("...\n\n      right: isMobile ? '10px' : 'auto',", "      right: isMobile ? '10px' : 'auto',")
+
+with open("client/src/components/CustomizationSettings.tsx", "w") as f:
+    f.write(content)


### PR DESCRIPTION
Removed modal wrapper from WorkspacesManager and fixed overlay wrapper from GroupChat to ensure they render smoothly inside the planets drawer. Added closeAllDrawers global functionality to ensure panels like mail and planets don't open simultaneously.

---
*PR created automatically by Jules for task [16844367831498816182](https://jules.google.com/task/16844367831498816182) started by @thuruht*